### PR TITLE
unittest dependency updates

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,4 +6,4 @@ homepage: https://github.com/jamesots/optionsfile
 environment:
   sdk: '>=0.8.10+6 <2.0.0'
 dependencies:
-  unittest: '>=0.9.0 <0.10.0'
+  unittest: '>=0.9.0 <0.12.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,5 +5,5 @@ description: Read options files
 homepage: https://github.com/jamesots/optionsfile
 environment:
   sdk: '>=0.8.10+6 <2.0.0'
-dependencies:
+dev_dependencies:
   unittest: '>=0.9.0 <0.12.0'


### PR DESCRIPTION
Importing options_file forced a downgrade of unittest, which broke my own tests. Made sure latest version (0.11.0+2) of unittest ran your tests, then made it a dev_dependency for good measure.
